### PR TITLE
Split CLI-only dependencies into an extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ Installation
 ------------
 Most users will want to simply install the latest version, hosted on PyPI:
 
-    $ pip install pyasstosrt
+    $ pip install "pyasstosrt[cli]"
+
+If you just want to use it as a library and don't need the CLI, you can omit the `[cli]` extra.

--- a/batch.py
+++ b/batch.py
@@ -1,15 +1,11 @@
-import sys
-
 try:
     import fire
     from pyfiglet import Figlet
 except ModuleNotFoundError:
-    print(
-        'ERROR: pyasstosrt was installed without the cli extra. '
-        'Please reinstall it with: pip install "pyasstosrt[cli]"',
-        file=sys.stderr
+    raise ImportError(
+        'pyasstosrt was installed without the cli extra. '
+        'Please reinstall it with: pip install "pyasstosrt[cli]"'
     )
-    sys.exit(1)
 
 from pyasstosrt import Subtitle, __version__
 

--- a/batch.py
+++ b/batch.py
@@ -1,5 +1,15 @@
-import fire
-from pyfiglet import Figlet
+import sys
+
+try:
+    import fire
+    from pyfiglet import Figlet
+except ModuleNotFoundError:
+    print(
+        'ERROR: pyasstosrt was installed without the cli extra. '
+        'Please reinstall it with: pip install "pyasstosrt[cli]"',
+        file=sys.stderr
+    )
+    sys.exit(1)
 
 from pyasstosrt import Subtitle, __version__
 

--- a/setup.py
+++ b/setup.py
@@ -19,18 +19,18 @@ setup(
     version=version,
     description="Convert ASS subtitle to SRT format",
     long_description=read('README.md'),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author="Ivan Vyalov",
     author_email="me@bnff.website",
     url="https://github.com/GitBib/pyasstosrt",
-    download_url='https://github.com/GitBib/pyasstosrt/archive/{}.zip'.format(
+    download_url="https://github.com/GitBib/pyasstosrt/archive/{}.zip".format(
         version
     ),
     license="Apache License, Version 2.0, see LICENSE file",
     packages=find_packages(exclude=["tests", "testapp"]),
-    install_requires=['setuptools'],
-    extras_require={'cli': ['fire>=0.3.1', 'pyfiglet']},
-    py_modules=['batch'],
+    install_requires=["setuptools"],
+    extras_require={"cli": ["fire>=0.3.1", "pyfiglet"]},
+    py_modules=["batch"],
     entry_points="""
     [console_scripts]
     pyasstosrt = batch:main

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     ),
     license="Apache License, Version 2.0, see LICENSE file",
     packages=find_packages(exclude=["tests", "testapp"]),
-    install_requires=['setuptools', 'fire>=0.3.1', 'pyfiglet'],
+    install_requires=['setuptools'],
+    extras_require={'cli': ['fire>=0.3.1', 'pyfiglet']},
     py_modules=['batch'],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
This allows people to depend on pyasstosrt as a library without pulling in `fire` and `pyfiglet` (and indirectly `termcolor`) as dependencies.