### PR TITLE
Exclude test files from build distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,15 @@ dev = [
 
 [tool.hatch.build.targets.sdist]
 include = ["pyasstosrt"]
+exclude = ["tests", "tests/*"]
 
 [tool.hatch.build.targets.wheel]
 include = ["pyasstosrt"]
+exclude = ["tests", "tests/*"]
 
 [tool.pdm.build]
 includes = ["pyasstosrt"]
+excludes = ["tests", "tests/*"]
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
This change ensures that test files and directories are excluded from sdist, wheel, and PDM builds. By reducing unnecessary files in distributions, the package becomes cleaner and more lightweight.