### PR TITLE
Refactor dependency declaration for `typer`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,9 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = [
-    "typer[all]>=0.15.2",
-]
 
 [project.optional-dependencies]
-cli = ["typer[all]>=0.15.2"]
+cli = ["typer>=0.15.2"]
 
 [project.urls]
 Homepage = "https://github.com/GitBib/pyasstosrt"

--- a/uv.lock
+++ b/uv.lock
@@ -494,9 +494,6 @@ wheels = [
 name = "pyasstosrt"
 version = "1.4.1"
 source = { editable = "." }
-dependencies = [
-    { name = "typer" },
-]
 
 [package.optional-dependencies]
 cli = [
@@ -516,10 +513,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "typer", extras = ["all"], specifier = ">=0.15.2" },
-    { name = "typer", extras = ["all"], marker = "extra == 'cli'", specifier = ">=0.15.2" },
-]
+requires-dist = [{ name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.2" }]
 provides-extras = ["cli"]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Moved `typer` dependency to optional `cli` extras and adjusted its specification. This simplifies the core dependencies while maintaining flexibility for CLI-related features.