### PR TITLE
Bump version to 1.4.2 and expand project keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyasstosrt"
-version = "1.4.1"
+version = "1.4.2"
 description = "Convert ASS subtitle to SRT format"
 authors = [{ name = "GitBib", email = "me@bnff.website" }]
 requires-python = ">=3.8"
@@ -10,6 +10,18 @@ keywords = [
     "ASS subtitle",
     "SRT",
     "Convert",
+    "subtitle",
+    "subtitles",
+    "Advanced SubStation Alpha",
+    "SubRip",
+    "conversion",
+    "subtitle conversion",
+    "caption",
+    "captions",
+    "batch conversion",
+    "video",
+    "media",
+    "CLI",
 ]
 classifiers = [
     "Operating System :: OS Independent",


### PR DESCRIPTION
Update the version to 1.4.2 in preparation for the new release. Add additional keywords to improve discoverability, covering related terms like subtitles, captions, and media conversion.