### PR TITLE
Update pre-commit hooks and add uv-lock hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,18 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.1
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [ --fix ]
         types_or: [ python, pyi ]
       - id: ruff-format
         types_or: [ python, pyi ]
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.6.9
+    hooks:
+      - id: uv-lock
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:


### PR DESCRIPTION
Upgrade the ruff-pre-commit hook to v0.11.2 for latest fixes. Add the uv-pre-commit repository with the uv-lock hook to enhance pre-commit functionality. These changes improve code quality and dependency locking.