### PR TITLE
Remove redundant Python setup steps from workflows

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -18,11 +18,6 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,11 +19,6 @@ jobs:
         tag="${GITHUB_REF#refs/*/}" # refs/tags/1.2.3 -> 1.2.3
         echo "tag=$tag" >> $GITHUB_OUTPUT
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,11 +17,6 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Install uv
       id: setup-uv
       uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
The `actions/setup-python` steps were removed as they are unnecessary due to the `astral-sh/setup-uv` action handling the required environment setup. This simplifies the workflows and avoids redundant configurations.