### PR TITLE
Bump `pyasstosrt` to version 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyasstosrt"
-version = "1.4.3"
+version = "1.5.0"
 description = "Convert ASS subtitle to SRT format"
 authors = [{ name = "GitBib", email = "me@bnff.website" }]
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "pyasstosrt"
-version = "1.4.3"
+version = "1.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Update the `pyasstosrt` library version in project files to 1.5.0. This ensures compatibility with the latest features and fixes provided by the library. No additional changes are included in this update.